### PR TITLE
Move tariff to devDependencies because it is used only for build the package

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "type": "git",
     "url": "git://github.com/marijnh/ist.git"
   },
-  "dependencies": {
+  "devDependencies": {
     "tariff": "^0.1.0"
   },
   "scripts": {


### PR DESCRIPTION
`tariff` looks not necessary for users of `ist` package, so this pull request moves the dependency to `devDependencies`.

